### PR TITLE
Support installed packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,15 @@ branch = True
 source = .
 omit =
     */.tox/*
-    */.nox/*
+    */__main__.py
     */setup.py
     */venv*/*
-    */.venv*/*
 ```
 
-Note: if you enable installed packages the python environment folders
-(``.tox`, ``.nox`, ``.venv*``, ``venv*``) might not be added statically, but
-instead exploded for folders going into the python virtual environment
-to avoid excluding the installed packages path.
+Note: if you enable installed packages the python environment folders (`.tox`,
+`venv*`) might not be added like here, but instead exploded for folders going
+into the python virtual environment to avoid excluding the installed packages
+path.
 
 ### `[coverage:report]`
 
@@ -158,20 +157,20 @@ defaults provided by `covdefaults`).
 #### coverage for installed libraries
 
 By default ``covdefaults`` assumes that you want to track coverage
-in your local source tree, code that is version controlled. For libraries
-it's better idea to detect coverage on your installed version, and map that
-back to the source files. You can enable tracking installed libraries via:
+in your local source tree, code that is version controlled. To detect
+coverage on your installed version, and map that back to the source files.
+You can enable tracking installed libraries via:
 
 ```ini
 [coverage:covdefaults]
-installed_libraries = tox:src virtualenv:.
+installed_libraries = tox:src virtualenv
 ```
 
 In this example we say we'll track the installed package/module tox that maps
 back to the source folder present at ``src``, and ``virtualenv`` that maps back
 to the source folder present at ``.``. Note the installed package/module must be
 present in either the ``platlib`` or ``purelib`` path of the virtual environment
-as specified by ``distutils`` ``install`` object.
+as specified by ``sysconfig``.
 
 ```ini
 [covdefaults]
@@ -188,9 +187,6 @@ defaults provided by `covdefaults`).
 exclude_lines =
     ^if MYPY:$
 ```
-
-this will result in lines matching `^if MYPY:$` to additionally be excluded
-from coverage in addition to the defaults provided by `covdefaults`.
 
 #### `report:fail_under`
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ exclude_lines =
     ^if MYPY:$
 ```
 
+this will result in lines matching `^if MYPY:$` to additionally be excluded
+from coverage in addition to the defaults provided by `covdefaults`.
+
 #### `report:fail_under`
 
 ```ini

--- a/README.md
+++ b/README.md
@@ -46,10 +46,16 @@ branch = True
 source = .
 omit =
     */.tox/*
-    */__main__.py
+    */.nox/*
     */setup.py
     */venv*/*
+    */.venv*/*
 ```
+
+Note: if you enable installed packages the python environment folders
+(``.tox`, ``.nox`, ``.venv*``, ``venv*``) might not be added statically, but
+instead exploded for folders going into the python virtual environment
+to avoid excluding the installed packages path.
 
 ### `[coverage:report]`
 
@@ -140,6 +146,32 @@ omit =
 
 this will result in the `pre_commit/resources/*` being `omit`ted in addition
 to the defaults provided by `covdefaults`.
+
+```ini
+[covdefaults]
+subtract_omit = */.tox/*
+```
+
+this will result in `*/.tox/*` not being `omit`ted (`*/.tox/*` is among the
+defaults provided by `covdefaults`).
+
+#### coverage for installed libraries
+
+By default ``covdefaults`` assumes that you want to track coverage
+in your local source tree, code that is version controlled. For libraries
+it's better idea to detect coverage on your installed version, and map that
+back to the source files. You can enable tracking installed libraries via:
+
+```ini
+[coverage:covdefaults]
+installed_libraries = tox:src virtualenv:.
+```
+
+In this example we say we'll track the installed package/module tox that maps
+back to the source folder present at ``src``, and ``virtualenv`` that maps back
+to the source folder present at ``.``. Note the installed package/module must be
+present in either the ``platlib`` or ``purelib`` path of the virtual environment
+as specified by ``distutils`` ``install`` object.
 
 ```ini
 [covdefaults]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ classifiers =
 [options]
 py_modules = covdefaults
 install_requires =
-    coverage>=4.5
+    coverage>=5.1
 python_requires = >=3.6.1
 
 [bdist_wheel]


### PR DESCRIPTION
Resolves #3.

- removes not tracking ``__main__``; this should be covered via the ``if __main__`` part; and I don't think it's bad practice to put code into the ``__main__.py``.
- adds ``.venv`` as python environment folders as per https://discuss.python.org/t/trying-to-come-up-with-a-default-directory-name-for-virtual-environments/3750 seems also a popular choice
- adds ``.nox`` to also handle people using nox instead of tox