### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:
@@ -37,7 +37,7 @@ repos:
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38]
+    toxenvs: [py37, py38, py39, py310]
     os: linux

--- a/covdefaults.py
+++ b/covdefaults.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 import os
 import sys
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Tuple
 
 from coverage import CoveragePlugin
 from coverage.config import CoverageConfig
@@ -20,7 +19,7 @@ _ALL = (
 )
 
 
-def _plat_impl_pragmas() -> List[str]:
+def _plat_impl_pragmas() -> list[str]:
     tags = {os.name, sys.platform, sys.implementation.name}
     ret = [fr'# pragma: {tag} cover\b' for tag in _ALL if tag not in tags]
     ret.extend(fr'# pragma: {tag} no cover\b' for tag in tags)
@@ -59,7 +58,7 @@ def _gt(n: int) -> str:
 def _version_pragmas(
         major: int = sys.version_info[0],
         minor: int = sys.version_info[1],
-) -> List[str]:
+) -> list[str]:
     return [
         # <
         fr'# pragma: <=?{_lt(major)}\.\d+ cover\b',
@@ -75,7 +74,7 @@ def _version_pragmas(
     ]
 
 
-OPTIONS: Tuple[Tuple[str, Any], ...] = (
+OPTIONS: tuple[tuple[str, Any], ...] = (
     ('run:branch', True),
 
     ('report:show_missing', True),
@@ -147,5 +146,5 @@ class CovDefaults(CoveragePlugin):
             config.set_option('report:fail_under', 100)
 
 
-def coverage_init(reg: Plugins, options: Dict[str, str]) -> None:
+def coverage_init(reg: Plugins, options: dict[str, str]) -> None:
     reg.add_configurer(CovDefaults(**options))

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,7 +24,7 @@ classifiers =
 py_modules = covdefaults
 install_requires =
     coverage>=6.0.2
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [bdist_wheel]
 universal = True

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/tests/covdefaults_test.py
+++ b/tests/covdefaults_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import re
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pre-commit
+envlist = py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos