### PR TITLE
Add `assert_never` to coverage ignore rules

### DIFF
--- a/covdefaults.py
+++ b/covdefaults.py
@@ -97,6 +97,7 @@ EXTEND = (
             r': \.\.\.(\s*#.*)?$',
             r'^ +\.\.\.$',
             r'-> [\'"]?NoReturn[\'"]?:',
+            r'^\s*assert_never\b',
             # non-runnable code
             r'^if __name__ == [\'"]__main__[\'"]:$',
             *_plat_impl_pragmas(),

--- a/tests/covdefaults_test.py
+++ b/tests/covdefaults_test.py
@@ -170,6 +170,7 @@ def test_exclude_lines_does_not_include_defaults(configured):
         '    if False:\n',
         'if TYPE_CHECKING:\n',
         '    if TYPE_CHECKING:\n',
+        'assert_never(instance)',
         'def f(x: int) -> int: ...\n',
         'def f(x: int) -> int:\n    ...\n',
         'def f(x: int) -> C: ...# noqa: F821\n',


### PR DESCRIPTION
Since `assert_never` is not expected to be ever executed, I think it might be a good idea. See https://docs.python.org/3/library/typing.html#typing.assert_never