### PR TITLE
Respect user-specified `report:fail_under = 0`

### DIFF
--- a/covdefaults.py
+++ b/covdefaults.py
@@ -143,7 +143,7 @@ class CovDefaults(CoveragePlugin):
         config.set_option('report:exclude_lines', sorted(exclude))
 
         # fail_under: if they specify a value then honor it
-        if not config.get_option('report:fail_under'):
+        if config.get_option('report:fail_under') is not None:  # can be 0
             config.set_option('report:fail_under', 100)
 
 

--- a/tests/covdefaults_test.py
+++ b/tests/covdefaults_test.py
@@ -226,6 +226,13 @@ def test_configure_keeps_existing_fail_under():
     assert cfg.get_option('report:fail_under') == 42
 
 
+def test_configure_keeps_existing_fail_under_zero():
+    cfg = CoverageConfig()
+    cfg.set_option('report:fail_under', 0)
+    configure(cfg)
+    assert cfg.get_option('report:fail_under') == 0
+
+
 def test_coverage_init():
     cfg = CoverageConfig()
     plugin_manager = Plugins.load_plugins(['covdefaults'], cfg)


### PR DESCRIPTION
As the README documents:

> 
> #### `report:fail_under`
> 
> ```ini
> [report]
> fail_under = 90
> ```
> 
> `covdefaults` will not change the value if you provide one for `fail_under`

Users may set `report:fail_under = 0` to disable `covdefaults` to put `fail_under = 100`.

In some settings, `coverage`'s `fail_under` may not work as expected. For example:

- Linux ppc64le simulated on amd64 https://github.com/metaopt/optree/actions/runs/13993162214/job/39181564281?pr=204
- Linux s390x simulated on amd64 https://github.com/metaopt/optree/actions/runs/13993162214/job/39181564284?pr=204
- Windows with Python built with `--with-pydebug` https://github.com/metaopt/optree/actions/runs/13993162191/job/39181563959?pr=204

```
CoverageWarning: Trace function changed, data is likely wrong: None != <bound method PyTracer._trace of <PyTracer at 0x1b9834538c0: 2270 data points in 14 files>> (trace-changed)
```

The expected coverage is 100%, but I got the wrong coverage at 50.89%. Then this fails the program unexpectedly.

So, `covdefaults` should allow users to set `report:fail_under = 0`.