### PR TITLE
Support Coverage 7.7.0 and above

### DIFF
--- a/tests/covdefaults_test.py
+++ b/tests/covdefaults_test.py
@@ -228,7 +228,8 @@ def test_configure_keeps_existing_fail_under():
 
 def test_coverage_init():
     cfg = CoverageConfig()
-    plugin_manager = Plugins.load_plugins(['covdefaults'], cfg)
+    plugin_manager = Plugins()
+    plugin_manager.load_from_config(['covdefaults'], cfg)
     assert plugin_manager.get('covdefaults.CovDefaults')
 
 


### PR DESCRIPTION
Coverage 7.7.0 refactored the way the Plugins class is used, and as a consequence, the load_plugins method was renamed, and is no longer a class method. Check if the new method exists, and fall back to the older method otherwise.